### PR TITLE
Cập nhật chức năng xóa manga trong MangaController và MangaService

### DIFF
--- a/src/manga/manga.controller.ts
+++ b/src/manga/manga.controller.ts
@@ -1,5 +1,6 @@
 import { 
-    BadRequestException, Body, Controller, Get, Param, Post, Put, Req, Res, UploadedFile, UploadedFiles, UseInterceptors, Query, ParseIntPipe, HttpStatus 
+    BadRequestException, Body, Controller, Get, Param, Post, Put, Req, Res, UploadedFile, UploadedFiles, UseInterceptors, Query, ParseIntPipe, HttpStatus, 
+    Delete
 } from '@nestjs/common';
 import { MangaService } from './manga.service';
 import { Manga } from './schemas/manga.schema';
@@ -321,5 +322,12 @@ export class MangaController {
         }
 
         return this.mangaService.getPendingMangas(page, limit);
+    }
+
+    @Auth({ roles:[Role.ADMIN, Role.UPLOADER], requireVerified: true })
+    @ApiOperation({ summary: 'Xóa manga' })
+    @Delete('/:id')
+    async deleteManga(@Param('id') id: string, @Req() req: any): Promise<void> {
+        return this.mangaService.deleteManga(id, req.user._id)
     }
 }

--- a/src/manga/manga.service.ts
+++ b/src/manga/manga.service.ts
@@ -1082,38 +1082,45 @@ export class MangaService {
 
     async deleteManga(mangaId: string, userId: string): Promise<void> {
         try {
-            const mangaObjectId = new mongoose.Types.ObjectId(mangaId);
-            const userObjectId = new mongoose.Types.ObjectId(userId);
+            const mangaObjectId = new mongoose.Types.ObjectId(mangaId);//1
+            const userObjectId = new mongoose.Types.ObjectId(userId);//2
 
             const [manga, user] = await Promise.all([
                 this.mangaModel.findById(mangaObjectId)
                     .populate('uploader'),
                 this.userModel.findById(userObjectId)
                     .select('role')
-            ]);
+            ]);//3
             
+
+            //4
             if (!manga) {
-                throw new NotFoundException(`Manga với ID: ${mangaId} không tồn tại`);
+                throw new NotFoundException(`Manga với ID: ${mangaId} không tồn tại`);//5
             }
 
+            //6
             if (!user) {
-                throw new NotFoundException(`User với ID: ${userId} không tồn tại`);
+                throw new NotFoundException(`User với ID: ${userId} không tồn tại`);//7
             }
 
-            const isAdmin = user.role === 'admin';
-            const isUploader = manga.uploader.toString() === userId;
+            const isAdmin = user.role === 'admin';//8
+            const isUploader = manga.uploader.toString() === userId;//9
 
+            //10
             if (!isAdmin || !isUploader) {
-                throw new ForbiddenException('Bạn không có quyền xóa manga này!');
+                throw new ForbiddenException('Bạn không có quyền xóa manga này!');//11
             }
 
+            //12
             if (manga.genre && manga.genre.length > 0) {
+                //13
                 await this.genreModel.updateMany(
                     { _id: { $in: manga.genre } },
                     { $pull: { manga: mangaObjectId } }
                 );
             }
 
+            //14
             await this.userModel.updateMany(
                 {},
                 {
@@ -1127,6 +1134,7 @@ export class MangaService {
                 }
             );
 
+            //15
             await Promise.all([
                 this.viewLogModel.deleteMany({ manga: mangaObjectId }),
                 this.mangaModel.findByIdAndDelete(mangaObjectId)


### PR DESCRIPTION
- Thêm endpoint xóa manga trong MangaController với xác thực cho vai trò ADMIN và UPLOADER.
- Cập nhật logic trong MangaService để kiểm tra quyền xóa manga, đảm bảo chỉ người dùng có vai trò phù hợp mới có thể thực hiện hành động này.
- Cải thiện thông báo lỗi khi không tìm thấy manga hoặc người dùng, đảm bảo tính rõ ràng trong phản hồi.